### PR TITLE
[FIX] fetchmail_attach_from_folder,mail_cleanup: fetch_mail() acepta raise_exception

### DIFF
--- a/fetchmail_attach_from_folder/models/fetchmail_server.py
+++ b/fetchmail_attach_from_folder/models/fetchmail_server.py
@@ -66,10 +66,12 @@ class FetchmailServer(models.Model):
         self.state = "draft"
         return result
 
-    def fetch_mail(self):
+    def fetch_mail(self, raise_exception=True):
         result = True
         for this in self:
             if not this.folders_only:
-                result = result and super(FetchmailServer, this).fetch_mail()
+                result = result and super(FetchmailServer, this).fetch_mail(
+                    raise_exception=raise_exception
+                )
             this.folder_ids.fetch_mail()
         return result

--- a/mail_cleanup/models/fetchmail_server.py
+++ b/mail_cleanup/models/fetchmail_server.py
@@ -109,7 +109,7 @@ class FetchmailServer(models.Model):
             failed,
         )
 
-    def fetch_mail(self):
+    def fetch_mail(self, raise_exception=True):
         # Called before the fetch, in order to clean up right before
         # retrieving emails.
         for server in self:
@@ -140,4 +140,4 @@ class FetchmailServer(models.Model):
                     if imap_server:
                         imap_server.close()
                         imap_server.logout()
-        return super().fetch_mail()
+        return super().fetch_mail(raise_exception=raise_exception)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ odoorpc
 openupgradelib
 paramiko<4.0.0
 pysftp
-sentry_sdk>=1.9.0,<=2.22.0
+sentry_sdk>=2.0.0,<=2.22.0


### PR DESCRIPTION
## Resumen
El core de `mail` en 18.0 (`fetchmail.py:213`, `_fetch_mails`) llama a `fetch_mail(raise_exception=False)`. Los overrides en `fetchmail_attach_from_folder` y `mail_cleanup` no declaraban ese parámetro, rompiendo el cron "Mail: Fetchmail Service" en cada ciclo con `TypeError: fetch_mail() got an unexpected keyword argument 'raise_exception'`.

Detectado en producción (aures18) tras la migración 16→18: el correo entrante dejaba de generar tareas/leads vía alias porque el cron fallaba silenciosamente en bucle.

## Cambios
- `fetchmail_attach_from_folder/models/fetchmail_server.py`: `fetch_mail(self, raise_exception=True)`, propaga el kwarg al `super()`.
- `mail_cleanup/models/fetchmail_server.py`: mismo patrón.

## Test plan
- [x] Aplicado en caliente en `aures18` de producción, restart, cron "Mail: Fetchmail Service" corre sin error.
- [x] Correo de prueba a `soporte@aurestic.es` genera la tarea esperada vía alias `soporte` → `project.task`.