### PR TITLE
[FIX] revertir sentry_sdk>=2.0.0: rompe build (urllib3==1.26.5 fijado en OCB)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ odoorpc
 openupgradelib
 paramiko<4.0.0
 pysftp
-sentry_sdk>=2.0.0,<=2.22.0
+sentry_sdk>=1.9.0,<=2.22.0


### PR DESCRIPTION
## Resumen
PR #21 subió el límite inferior de `sentry_sdk` a `>=2.0.0` a petición del hook `oca-gen-external-dependencies` de pre-commit, sin comprobar compatibilidad real con el resto del stack.

Toda versión de `sentry_sdk>=2.0.0` requiere `urllib3>=1.26.11`, pero `odoo/requirements.txt` (usado como `-c` constraint en el `pip install`) fija `urllib3==1.26.5` — conflicto irresoluble (`ResolutionImpossible`). Rompe el build de **cualquier** imagen que dependa de `server-tools` sobre ese OCB, no solo la de un cliente.

Confirmado con el log real de Jenkins (build `BuildOdooImage #12256`, aures18-004213:test):
```
ERROR: Cannot install -r .../server-tools/requirements.txt (line 9) because these package versions have conflicting dependencies.
The conflict is caused by:
    sentry-sdk 2.22.0 depends on urllib3>=1.26.11
    ...
    The user requested (constraint) urllib3==1.26.5
```

## Cambio
Revertir `sentry_sdk>=2.0.0,<=2.22.0` → `sentry_sdk>=1.9.0,<=2.22.0`.

El desajuste real (el módulo `sentry` declara necesitar `>=2.0.0` en su manifest, pero solo `1.9.0` es instalable bajo el constraint de urllib3) sigue existiendo — se gestiona desinstalando el módulo `sentry` post-migración vía SQL (ver `18.0.sql` en `nubeaerp_004213`), no subiendo aquí el rango de la dependencia.

## Test plan
- [ ] Relanzar build de test tras mergear, confirmar que `pip install -r server-tools/requirements.txt` resuelve sin conflicto.